### PR TITLE
feat(ci): split build steps into a separate action file

### DIFF
--- a/.github/actions/soluna/action.yml
+++ b/.github/actions/soluna/action.yml
@@ -1,0 +1,154 @@
+name: Build Soluna
+description: Build Soluna for different operating systems
+
+inputs:
+  soluna_path:
+    description: 'The path to the Soluna repository. Defaults to .'
+    required: false
+    default: '.'
+
+outputs:
+  SOLUNA_BINARY:
+    description: 'The name of the built Soluna binary.'
+    value: ${{ steps.set-output.outputs.SOLUNA_BINARY }}
+  SOLUNA_PATH:
+    description: 'The path to the built Soluna binary.'
+    value: ${{ steps.set-output.outputs.SOLUNA_PATH }}
+  SOLUNA_WASM_PATH:
+    description: 'The path to the built Soluna WebAssembly binary.'
+    value: ${{ steps.set-output.outputs.SOLUNA_WASM_PATH }}
+  SOLUNA_JS_PATH:
+    description: 'The path to the Soluna JavaScript glue code for WebAssembly.'
+    value: ${{ steps.set-output.outputs.SOLUNA_JS_PATH }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get the soluna commit
+      id: refs
+      working-directory: ${{ inputs.soluna_path }}
+      run: |
+        echo "commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Cache soluna build
+      uses: actions/cache@v4
+      id: cache
+      with:
+        path: ${{ inputs.soluna_path }}/bin
+        key: ${{ runner.os }}-soluna-build-${{ steps.refs.outputs.commit }}
+    - name: Checkout all submodules
+      if: steps.cache.outputs.cache-hit != 'true'
+      working-directory: ${{ inputs.soluna_path }}
+      run: |
+        git submodule update --init --recursive
+      shell: bash
+    - uses: actions/checkout@v5
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        repository: floooh/sokol-tools-bin
+        ref: "a06f19929ff8f9824ec6dd87c21329b1f205809e"
+        path: sokol-tools-bin
+        fetch-depth: 1
+    - name: Setup sokol-shdc
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          TARGET_DIR="C:/Windows/System32"
+          SHDC_BINARY="sokol-shdc.exe"
+          FIND_PATH="bin/win32"
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          TARGET_DIR="/usr/local/bin"
+          SHDC_BINARY="sokol-shdc"
+          FIND_PATH="bin/osx_arm64"
+        else  # Linux
+          TARGET_DIR="/usr/local/bin"
+          SHDC_BINARY="sokol-shdc"
+          FIND_PATH="bin/linux"
+        fi
+        echo "Setting up sokol-tools from sokol-tools-bin/$FIND_PATH"
+        find sokol-tools-bin/$FIND_PATH -name $SHDC_BINARY -exec cp {} $TARGET_DIR \;
+        $SHDC_BINARY -h
+    - uses: yuchanns/actions-luamake@v1
+      if: steps.cache.outputs.cache-hit != 'true'
+      with:
+        luamake-version: "5bedfce66f075a9f68b1475747738b81b3b41c25"
+    - name: Install Dependencies (Linux)
+      shell: bash
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential \
+          libgl1-mesa-dev libglu1-mesa-dev libx11-dev \
+          libxrandr-dev libxi-dev libxxf86vm-dev libxcursor-dev \
+          libasound2-dev libfontconfig1-dev
+    - name: Build (Windows)
+      if: runner.os == 'Windows' && steps.cache.outputs.cache-hit != 'true'
+      shell: powershell
+      id: build-windows
+      working-directory: ${{ inputs.soluna_path }}
+      run: |
+        luamake clean
+        luamake precompile
+        luamake soluna
+        $SOLUNA_BINARY = "soluna.exe"
+        $RENAME_BINARY = "soluna-windows-amd64.exe"
+        $SOLUNA_PATH = (Get-ChildItem -Path "bin" -Name $SOLUNA_BINARY -Recurse | Select-Object -First 1)
+        Copy-Item "bin\$SOLUNA_PATH" "bin\$RENAME_BINARY"
+        echo "SOLUNA_PATH=bin/$RENAME_BINARY" >> $GITHUB_OUTPUT
+        echo "SOLUNA_BINARY=$RENAME_BINARY" >> $GITHUB_OUTPUT
+    - name: Build (Unix)
+      if: runner.os != 'Windows' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: ${{ inputs.soluna_path }}
+      run: |
+        luamake precompile
+        luamake soluna
+        if [[ "$RUNNER_OS" == "Linux" ]]; then
+          RENAME_BINARY="soluna-linux-amd64"
+        elif [[ "$RUNNER_OS" == "macOS" ]]; then
+          RENAME_BINARY="soluna-macos-arm64"
+        else
+          echo "Unsupported OS: $RUNNER_OS"
+          exit 1
+        fi
+    - uses: mymindstorm/setup-emsdk@v14
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      with:
+        version: 4.0.17
+        actions-cache-folder: 'emsdk-cache'
+    - name: Build Emscripten
+      if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
+      working-directory: ${{ inputs.soluna_path }}
+      shell: bash
+      run: |
+        luamake -compiler emcc precompile
+        luamake -compiler emcc
+        SOLUNA_JS="soluna.js"
+        SOLUNA_JS_PATH=$(find bin -name $SOLUNA_JS | head -n 1)
+        sed -i 's/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32),dynamicOffsetsPtr>>2,dynamicOffsetCount)/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32).subarray(dynamicOffsetsPtr>>2,(dynamicOffsetsPtr>>2)+dynamicOffsetCount))/g' "$SOLUNA_JS_PATH"
+    - name: Set Output Build Path
+      id: set-output
+      run: |
+        bin_dir=${{inputs.soluna_path}}/bin
+        if [ "${{ runner.os }}" == "Windows" ]; then
+          SOLUNA_BINARY="soluna.exe"
+          RENAME_BINARY="soluna-windows-amd64.exe"
+        elif [ "${{ runner.os }}" == "macOS" ]; then
+          SOLUNA_BINARY="soluna"
+          RENAME_BINARY="soluna-macos-arm64"
+        else
+          SOLUNA_BINARY="soluna"
+          RENAME_BINARY="soluna-linux-amd64"
+        fi
+        SOLUNA_PATH=$(find $bin_dir -name "$SOLUNA_BINARY" | head -n 1)
+        cp "$SOLUNA_PATH" "$bin_dir/$RENAME_BINARY"
+        echo "SOLUNA_PATH=$bin_dir/$RENAME_BINARY" >> $GITHUB_OUTPUT
+        echo "SOLUNA_BINARY=$RENAME_BINARY" >> $GITHUB_OUTPUT
+        if [ "${{ runner.os }}" == "Linux" ]; then
+          SOLUNA_WASM_PATH=$(find $bin_dir -name "soluna.wasm" | head -n 1)
+          SOLUNA_JS_PATH=$(find $bin_dir -name "soluna.js" | head -n 1)
+        fi
+        echo "SOLUNA_WASM_PATH=$SOLUNA_WASM_PATH" >> $GITHUB_OUTPUT
+        echo "SOLUNA_JS_PATH=$SOLUNA_JS_PATH" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,103 +74,19 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/checkout@v5
+      - uses: ./.github/actions/soluna
+        name: Build
+        id: build
         with:
-          repository: floooh/sokol-tools-bin
-          ref: "a06f19929ff8f9824ec6dd87c21329b1f205809e"
-          path: sokol-tools-bin
-          fetch-depth: 1
-      - name: Setup sokol-shdc
-        shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            TARGET_DIR="C:/Windows/System32"
-            SHDC_BINARY="sokol-shdc.exe"
-            FIND_PATH="bin/win32"
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            TARGET_DIR="/usr/local/bin"
-            SHDC_BINARY="sokol-shdc"
-            FIND_PATH="bin/osx_arm64"
-          else  # Linux
-            TARGET_DIR="/usr/local/bin"
-            SHDC_BINARY="sokol-shdc"
-            FIND_PATH="bin/linux"
-          fi
-          echo "Setting up sokol-tools from sokol-tools-bin/$FIND_PATH"
-          find sokol-tools-bin/$FIND_PATH -name $SHDC_BINARY -exec cp {} $TARGET_DIR \;
-          $SHDC_BINARY -h
-      - uses: yuchanns/actions-luamake@v1
-        with:
-          luamake-version: "5bedfce66f075a9f68b1475747738b81b3b41c25"
-      - name: Install Dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential \
-            libgl1-mesa-dev libglu1-mesa-dev libx11-dev \
-            libxrandr-dev libxi-dev libxxf86vm-dev libxcursor-dev \
-            libasound2-dev libfontconfig1-dev
-      - name: Build (Windows)
-        if: runner.os == 'Windows'
-        shell: powershell
-        id: build-windows
-        run: |
-          luamake clean
-          luamake precompile
-          luamake soluna
-          $SOLUNA_BINARY = "soluna.exe"
-          $RENAME_BINARY = "soluna-windows-amd64.exe"
-          $SOLUNA_PATH = (Get-ChildItem -Path "bin" -Name $SOLUNA_BINARY -Recurse | Select-Object -First 1)
-          Copy-Item "bin\$SOLUNA_PATH" "bin\$RENAME_BINARY"
-          echo "SOLUNA_PATH=bin/$RENAME_BINARY" >> $env:GITHUB_OUTPUT
-          echo "SOLUNA_BINARY=$RENAME_BINARY" >> $env:GITHUB_OUTPUT
-      - name: Build (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        id: build-unix
-        run: |
-          luamake precompile
-          luamake soluna
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            RENAME_BINARY="soluna-linux-amd64"
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            RENAME_BINARY="soluna-macos-arm64"
-          else
-            echo "Unsupported OS: $RUNNER_OS"
-            exit 1
-          fi
-          SOLUNA_BINARY="soluna"
-          SOLUNA_PATH=$(find bin -name $SOLUNA_BINARY | head -n 1)
-          cp "$SOLUNA_PATH" "bin/$RENAME_BINARY"
-          echo "SOLUNA_PATH=bin/$RENAME_BINARY" >> $GITHUB_OUTPUT
-          echo "SOLUNA_BINARY=$RENAME_BINARY" >> $GITHUB_OUTPUT
+          soluna_path: "."
       - uses: actions/upload-artifact@v4
         name: Upload
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
         with:
-          name: "soluna-${{ runner.os }}-${{ runner.os == 'Windows' && steps.build-windows.outputs.SOLUNA_BINARY || steps.build-unix.outputs.SOLUNA_BINARY }}"
+          name: "soluna-${{ runner.os }}-${{ steps.build.outputs.SOLUNA_BINARY }}"
           if-no-files-found: "error"
-          path: "${{ runner.os == 'Windows' && steps.build-windows.outputs.SOLUNA_PATH || steps.build-unix.outputs.SOLUNA_PATH }}"
+          path: "${{ steps.build.outputs.SOLUNA_PATH }}"
           overwrite: "true"
-      - uses: mymindstorm/setup-emsdk@v14
-        if: runner.os == 'Linux'
-        with:
-          version: 4.0.17
-          actions-cache-folder: 'emsdk-cache'
-      - name: Build Emscripten
-        if: runner.os == 'Linux'
-        shell: bash
-        id: build-emscripten
-        run: |
-          luamake -compiler emcc precompile
-          luamake -compiler emcc
-          SOLUNA_BINARY="soluna.wasm"
-          SOLUNA_PATH=$(find bin -name $SOLUNA_BINARY | head -n 1)
-          SOLUNA_JS="soluna.js"
-          SOLUNA_JS_PATH=$(find bin -name $SOLUNA_JS | head -n 1)
-          echo "SOLUNA_BINARY=$SOLUNA_PATH" >> $GITHUB_OUTPUT
-          echo "SOLUNA_JS=$SOLUNA_JS_PATH" >> $GITHUB_OUTPUT
-          sed -i 's/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32),dynamicOffsetsPtr>>2,dynamicOffsetCount)/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32).subarray(dynamicOffsetsPtr>>2,(dynamicOffsetsPtr>>2)+dynamicOffsetCount))/g' "$SOLUNA_JS_PATH"
       - uses: actions/upload-artifact@v4
         name: Upload Emscripten
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && runner.os == 'Linux'
@@ -179,8 +95,8 @@ jobs:
           if-no-files-found: "error"
           overwrite: "true"
           path: |
-            ${{ steps.build-emscripten.outputs.SOLUNA_BINARY }}
-            ${{ steps.build-emscripten.outputs.SOLUNA_JS }}
+            ${{ steps.build.outputs.SOLUNA_WASM_PATH }}
+            ${{ steps.build.outputs.SOLUNA_JS_PATH }}
   release:
     name: Create Nightly Release
     needs: [check, build]


### PR DESCRIPTION
- 将 GHA 中的 soluna 构建部分单独封装成一个 action.yml
- 添加了同 commit 的构建缓存

这样做的好处是，下游可以复用 soluna 的 GHA 构建脚本，并且当引擎没有更新时可以节省构建时间。例如：

现在 deepfuture 的 soluna 构建脚本是我单独又写了一遍，因此有双份维护成本。
其中涉及到了对 soluna 依赖 3rd 版本的构建管理以及对 Safari 兼容的 hack，实际上下游不应该关注。

当此 PR 合并后, deepfuture 的 soluna 构建可以简化成如下效果:

```diff
diff --git a/.github/workflows/deploy.yml b/.github/workflows/deploy.yml
index 492dc41..85d0594 100644
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Build Soluna
+    name: Build Runtime
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     strategy:
@@ -20,53 +20,17 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
-      - uses: actions/checkout@v5
-        with:
-          repository: floooh/sokol-tools-bin
-          ref: "a06f19929ff8f9824ec6dd87c21329b1f205809e"
-          path: sokol-tools-bin
-          fetch-depth: 1
-      - name: Setup sokol-shdc
-        shell: bash
-        run: |
-          TARGET_DIR="/usr/local/bin"
-          SHDC_BINARY="sokol-shdc"
-          FIND_PATH="bin/linux"
-          echo "Setting up sokol-tools from sokol-tools-bin/$FIND_PATH"
-          find sokol-tools-bin/$FIND_PATH -name $SHDC_BINARY -exec cp {} $TARGET_DIR \;
-          $SHDC_BINARY -h
-      - uses: yuchanns/actions-luamake@v1
+      - name: Build Soluna
+        uses: ./soluna/.github/actions/soluna
+        id: build
         with:
-          luamake-version: "5bedfce66f075a9f68b1475747738b81b3b41c25"
-      - name: Install Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential \
-            libgl1-mesa-dev libglu1-mesa-dev libx11-dev \
-            libxrandr-dev libxi-dev libxxf86vm-dev libxcursor-dev \
-            libasound2-dev libfontconfig1-dev
-      - uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: 4.0.17
-          actions-cache-folder: 'emsdk-cache'
-      - name: Build Emscripten
-        shell: bash
-        working-directory: soluna
-        run: |
-          luamake precompile
-          luamake -compiler emcc precompile
-          luamake -compiler emcc
+          soluna_path: "./soluna"
       - name: Prepare Game Content
         shell: bash
         run: |
           mkdir build
-          SOLUNA_BINARY="soluna.wasm"
-          SOLUNA_PATH=$(find soluna/bin -name $SOLUNA_BINARY | head -n 1)
-          SOLUNA_JS="soluna.js"
-          SOLUNA_JS_PATH=$(find soluna/bin -name $SOLUNA_JS | head -n 1)
-          sed -i 's/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32),dynamicOffsetsPtr>>2,dynamicOffsetCount)/setBindGroup(groupIndex,group,(growMemViews(),HEAPU32).subarray(dynamicOffsetsPtr>>2,(dynamicOffsetsPtr>>2)+dynamicOffsetCount))/g' "$SOLUNA_JS_PATH"
-          cp "$SOLUNA_PATH" ./build/
-          cp "$SOLUNA_JS_PATH" ./build/
+          cp "${{ steps.build.outputs.SOLUNA_WASM_PATH }}" ./build/
+          cp "${{ steps.build.outputs.SOLUNA_JS_PATH }}" ./build/
           zip -r ./build/main.zip asset core gameplay localization service visual main.game main.lua
           cp .github/assets/index.html ./build/
           cp .github/assets/font.zip ./build/
```

有利于未来(如果有)推广引擎(的打算)时，打消下游的构建顾虑，塑造一个 web 版 CI 自动化友好的形象 :)