### PR TITLE
修复luamake的编译错误和shader tool找不到的问题

### DIFF
--- a/clibs/sokol/make.lua
+++ b/clibs/sokol/make.lua
@@ -3,6 +3,8 @@ local fs = require "bee.filesystem"
 
 local deps = {}
 
+local shdc<const> = lm.shdc or ""
+
 local function compile_shader(src, name, lang)
   local dep = name .. "_shader"
   deps[#deps + 1] = dep
@@ -12,6 +14,7 @@ local function compile_shader(src, name, lang)
     inputs = lm.basedir .. "/" .. src,
     outputs = lm.basedir .. "/" .. target,
     args = {
+      shdc,
       "$in",
       "$out",
       lang,

--- a/clibs/sokol/shader2c.lua
+++ b/clibs/sokol/shader2c.lua
@@ -1,6 +1,6 @@
 local subprocess = require "bee.subprocess"
 local platform = require "bee.platform"
-local src, target, lang = ...
+local shdcexe, src, target, lang = ...
 
 local function find_executable(name)
   local handle = io.popen("where " .. name .. " 2>nul")
@@ -14,7 +14,9 @@ local function find_executable(name)
   return name
 end
 
-local shdcexe = platform.os == "windows" and find_executable("sokol-shdc.exe") or "sokol-shdc"
+if shdcexe == "" then
+  shdcexe = platform.os == "windows" and find_executable("sokol-shdc.exe") or "sokol-shdc"
+end
 
 local process = assert(subprocess.spawn {
   shdcexe,

--- a/clibs/soluna/make.lua
+++ b/clibs/soluna/make.lua
@@ -25,6 +25,9 @@ lm:source_set "soluna_src" {
   sources = {
     "src/*.c",
   },
+  objdeps = {
+    "compile_lua_code",
+  },
   defines = {
     commit and string.format('SOLUNA_HASH_VERSION=\\"%s\\"', commit),
   },

--- a/make.lua
+++ b/make.lua
@@ -126,7 +126,6 @@ lm:import "clibs/soluna/make.lua"
 lm:phony "precompile" {
   deps = {
     "compile_shaders",
-    "compile_lua_code",
   },
 }
 


### PR DESCRIPTION
1. 在编译soluna/src/embedlua.c文件前，没有把相关的lua转换成*.lua.h文件的话，会导致编译错误。原因是make.lua中的依赖没有写对。deps的依赖是在linking阶段，而objdeps是在编译阶段。由于*.lua.h在embedlua.c编译的时候就需要引用，故需要移到lm:source_set "soluna"定义位置，使用objdeps依赖；
2. 目前查找sokol的shader tool时会找不到，加了一个--shdc在调用luamake命令前，指定具体的位置。不指定的话，继续沿用之前的方法（但之前的方法还是找不多）；

有些建议：
1. compile_lua_code看起来并不需要依赖yoga，但现在写在yoga的make.lua里面了。看起来，这些*.lua.h只被soluna模块依赖，是不是应该放到soluna模块更合适；
2. 现在查找的sokol的shader编译工具的方法有问题，并且应该在找不到这个shader tool的时候，log出一些更有用的信息，例如打印上面的--shdc的用法；