### PR TITLE
fix: color format in material pq && description in docs

### DIFF
--- a/docs/material_mask.lua
+++ b/docs/material_mask.lua
@@ -10,11 +10,11 @@ local matmask = {}
 
 --- Creates a colored mask sprite.
 ---
---- Color format: 0xAARRGGBB (native-endian 32-bit integer).
+--- Color format: ARGB as 32-bit integer 0xAARRGGBB.
 --- If the alpha byte is 00 it is forced to 0xFF (fully opaque).
 ---
 ---@param sprite integer 1-based sprite index (will be stored as 0-based internally)
----@param color  integer Color in 0xAARRGGBB format (e.g. 0xFF00FF00 for opaque green)
+---@param color  integer Color in ARGB format (0xAARRGGBB, e.g. 0xFF00FF00 for opaque green)
 ---@return userdata mask Binary blob containing the packed mask_primitive; push it as a Lua string
 function matmask.mask(sprite, color) end
 

--- a/docs/material_perspective_quad.lua
+++ b/docs/material_perspective_quad.lua
@@ -18,7 +18,7 @@ local matproj = {}
 ---@field shear_x? number Local x shear (default: 0.0)
 ---@field shear_y? number Local y shear (default: 0.0)
 ---@field q? number[] Perspective factors as {q0,q1,q2,q3}, defaults to all 1.0
----@field color? integer Color tint in RGBA format (0xRRGGBBAA), default: 0xffffffff
+---@field color? integer Color tint in ARGB format (0xAARRGGBB), default: 0xffffffff
 
 ---
 --- Creates a perspective quad sprite command stream.

--- a/docs/material_quad.lua
+++ b/docs/material_quad.lua
@@ -10,12 +10,12 @@ local matquad = {}
 ---
 --- Creates a colored rectangle sprite
 ---
---- Color format: RGBA as 32-bit integer 0xRRGGBBAA.
+--- Color format: ARGB as 32-bit integer 0xAARRGGBB.
 --- If alpha channel (high byte) is 0, it defaults to 0xFF (opaque).
 ---
 ---@param width integer Rectangle width in pixels
 ---@param height integer Rectangle height in pixels
----@param color integer Color in RGBA format (0xRRGGBBAA, e.g., 0xFF0000FF for opaque red)
+---@param color integer Color in ARGB format (0xAARRGGBB, e.g., 0xFFFF0000 for opaque red)
 ---@return userdata sprite Sprite object for rendering with batch:add()
 function matquad.quad(width, height, color) end
 

--- a/docs/material_text.lua
+++ b/docs/material_text.lua
@@ -14,7 +14,8 @@ local mattext = {}
 --- 1. block(text, width, height) - creates a renderable text sprite
 --- 2. cursor(text, position, width, height) - calculates cursor position in text
 ---
---- Color format: RGBA as 32-bit integer. If alpha channel (high byte) is 0, defaults to 0xFF (opaque).
+--- Color format: ARGB as 32-bit integer 0xAARRGGBB.
+--- If alpha channel (high byte) is 0, defaults to 0xFF (opaque).
 --- Alignment codes (case-insensitive, can be combined):
 ---   Horizontal: L (left), C (center), R (right)
 ---   Vertical: T (top), V (center), B (bottom)
@@ -23,7 +24,7 @@ local mattext = {}
 ---@param fontcobj userdata Font system C object from font.cobj()
 ---@param fontid integer Font ID from font.name()
 ---@param size? integer Font size in pixels (default: 16)
----@param color? integer Text color (RGBA as 0xRRGGBBAA, default: 0xff000000 = opaque black)
+---@param color? integer Text color (ARGB as 0xAARRGGBB, default: 0xff000000 = opaque black)
 ---@param alignment? string Alignment code (default: no alignment)
 ---@return fun(text: string, width: integer, height: integer): userdata block_function Creates text sprite
 ---@return fun(text: string, position: integer, width: integer, height: integer): integer, integer, integer, integer, integer, integer cursor_function Returns x, y, w, h, actual_position, descent


### PR DESCRIPTION
1. 修复几处文档颜色参数描述错误
2. 修复 perspective material 颜色入参格式与其他材质不统一的问题