### PR TITLE
feat(material/pquad): remove .w/.h/.ox/.oy and use sprite rect

### DIFF
--- a/asset/sprites.dl
+++ b/asset/sprites.dl
@@ -3,3 +3,9 @@ name : avatar
 filename : avatar.png
 x : -0.5
 y : -1
+
+--
+name : avatar2
+filename : avatar.png
+x : -0.5
+y : -0.5

--- a/docs/material_perspective_quad.lua
+++ b/docs/material_perspective_quad.lua
@@ -9,10 +9,6 @@ local matproj = {}
 
 ---@class soluna.material.perspective_quad.options
 ---@field quad? number[] Local quad coordinates as {x0,y0,x1,y1,x2,y2,x3,y3}
----@field w? number Width used when `quad` is not provided
----@field h? number Height used when `quad` is not provided
----@field ox? number Origin x offset for generated quad (default: 0)
----@field oy? number Origin y offset for generated quad (default: 0)
 ---@field scale_x? number Local x scale (default: 1.0)
 ---@field scale_y? number Local y scale (default: 1.0)
 ---@field shear_x? number Local x shear (default: 0.0)
@@ -25,9 +21,7 @@ local matproj = {}
 ---
 --- The result should be passed to `batch:add(...)`.
 --- The sprite index is 1-based, consistent with sprite bundle ids.
---- `scale_x/scale_y` are applied directly to local geometry.
---- If negative, geometry is reflected around local origin `(0, 0)`.
---- To mirror around a different axis, define `quad` around your desired pivot.
+--- Use `quad` for custom local geometry; otherwise use default sprite geometry.
 ---
 ---@param sprite integer 1-based sprite id
 ---@param options soluna.material.perspective_quad.options Perspective quad options

--- a/test/perspective_quad.lua
+++ b/test/perspective_quad.lua
@@ -10,7 +10,7 @@ local file = require "soluna.file"
 soluna.set_window_title "perspective quad regression matrix"
 
 local sprites = soluna.load_sprites "asset/sprites.dl"
-local avatar = assert(sprites.avatar)
+local avatar = assert(sprites.avatar2)
 
 local CARD_W <const> = 160
 local CARD_H <const> = 196
@@ -60,15 +60,6 @@ if fontid then
 	make_label = mattext.block(font.cobj(), fontid, 14, LABEL_TEXT, "CV")
 end
 local label_cache = {}
-
-local function rect_quad(w, h)
-	return {
-		-w * 0.5, -h * 0.5,
-		w * 0.5, -h * 0.5,
-		-w * 0.5, h * 0.5,
-		w * 0.5, h * 0.5,
-	}
-end
 
 local function card_quad(theta)
 	local dist = 460.0
@@ -122,32 +113,31 @@ end
 local args = ...
 local batch = args.batch
 local callback = {}
-local base_quad = rect_quad(CARD_W * 0.58, CARD_H * 0.58)
+local base_scale_x <const> = 0.58
+local base_scale_y <const> = 0.58
 
 local function draw_flip_cases(t)
 	local y = 126
 	draw_tile(batch, 110, y, 130, 160, "base")
-	draw_sprite(batch, 110, y, { quad = base_quad, color = WHITE })
+	draw_sprite(batch, 110, y, { scale_x = base_scale_x, scale_y = base_scale_y, color = WHITE })
 
 	draw_tile(batch, 250, y, 130, 160, "flip_x")
-	draw_sprite(batch, 250, y, { quad = base_quad, scale_x = -1.0, color = WHITE })
+	draw_sprite(batch, 250, y, { scale_x = -base_scale_x, scale_y = base_scale_y, color = WHITE })
 
 	draw_tile(batch, 390, y, 130, 160, "flip_y")
-	draw_sprite(batch, 390, y, { quad = base_quad, scale_y = -1.0, color = WHITE })
+	draw_sprite(batch, 390, y, { scale_x = base_scale_x, scale_y = -base_scale_y, color = WHITE })
 
 	draw_tile(batch, 530, y, 130, 160, "flip_xy")
 	draw_sprite(batch, 530, y, {
-		quad = base_quad,
-		scale_x = -1.0,
-		scale_y = -1.0,
+		scale_x = -base_scale_x,
+		scale_y = -base_scale_y,
 		color = WHITE,
 	})
 
 	draw_tile(batch, 670, y, 130, 160, "affine")
 	draw_sprite(batch, 670, y, {
-		quad = base_quad,
-		scale_x = 1.30,
-		scale_y = 0.74,
+		scale_x = base_scale_x * 1.30,
+		scale_y = base_scale_y * 0.74,
 		shear_x = math.sin(t * 0.8) * 0.40,
 		shear_y = math.cos(t * 0.7) * 0.16,
 		color = WHITE,


### PR DESCRIPTION
根据 #73 的后续讨论, 我认为应该移除掉 .w/.h/.ox/.oy, 由 submit 时读取 sprite bank 的 rect 数据. 对于自定义场景使用 .quad 应该就够了, 原本的 .w/.h/.ox/.oy 从 lua 层面处理成 .quad 就够了.