### PR TITLE
fix(platform/macos): do not consume keydown event without composition

### DIFF
--- a/src/platform/macos/soluna_macos_ime.m
+++ b/src/platform/macos/soluna_macos_ime.m
@@ -390,13 +390,12 @@ soluna_current_caret_screen_rect(NSView *view) {
 - (void)insertText:(id)string replacementRange:(NSRange)replacementRange {
     (void)replacementRange;
     NSString *plain = soluna_plain_string(string);
+    bool commit = (plain.length > 0) && g_soluna_macos_composition;
     soluna_store_marked_text(self, nil, NSMakeRange(NSNotFound, 0));
-    if (plain.length > 0) {
+    if (commit) {
         soluna_emit_nsstring(plain);
-        soluna_set_event_consumed(self, true);
-    } else {
-        soluna_set_event_consumed(self, false);
     }
+    soluna_set_event_consumed(self, commit);
     g_soluna_macos_composition = false;
     soluna_macos_hide_ime_label();
 }


### PR DESCRIPTION
修复在非输入法状态下, 键盘字母输入被吞掉的 bug