### PR TITLE
fix: invalid text_inst without text_sampler

### DIFF
--- a/src/service/render.lua
+++ b/src/service/render.lua
@@ -336,6 +336,7 @@ local function render_init(arg)
 
 			STATE.text_bindings = text_bindings
 		else
+			STATE.text_inst = STATE.inst
 			STATE.text_bindings = STATE.bindings
 		end
 	end


### PR DESCRIPTION
修复在没有设置 text_sampler 情况下的错误

see: https://github.com/cloudwu/deepfuture/pull/57#issuecomment-3915259287