### PR TITLE
fix(extlua): dangling preload names

### DIFF
--- a/src/external.c
+++ b/src/external.c
@@ -154,6 +154,14 @@ preload_libs(lua_State *L) {
 	lua_pushvalue(L, result_index);
 	lua_call(L, 2, 0);
 
+	for (i=0;i<n;i++) {
+		char *name = strdup(l[i].name);
+		if (name == NULL) {
+			return luaL_error(L, "Out of memory");
+		}
+		l[i].name = name;
+	}
+
 	qsort(l, n, sizeof(luaL_Reg), cmpreg);
 
 	PRELOAD.l = l;


### PR DESCRIPTION
preload 的模块名会被  gc 掉. 在 soluna pages 的 wasm 场景不知道为啥碰巧稳定没事。在我自己的项目里必现，而且只有 WASM 版有这个问题