### PR TITLE
feat(build/luamake): support audio

### DIFF
--- a/clibs/soloud/make.lua
+++ b/clibs/soloud/make.lua
@@ -1,0 +1,28 @@
+local lm = require "luamake"
+
+lm.rootdir = lm.basedir .. "/3rd/soloud"
+
+lm:source_set "soloud_src" {
+	sources = {
+		lm.basedir .. "/src/soloudone.cpp",
+	},
+	includes = {
+		"include",
+		"src",
+	},
+	windows = {
+		defines = {
+			"WITH_WINMM=1",
+		},
+	},
+	macos = {
+		defines = {
+			"WITH_COREAUDIO=1",
+		},
+	},
+	linux = {
+		defines = {
+			lm.platform == "emcc" and "WITH_SDL2_STATIC=1" or "WITH_ALSA=1",
+		},
+	},
+}

--- a/clibs/soluna/make.lua
+++ b/clibs/soluna/make.lua
@@ -39,10 +39,11 @@ lm:source_set "soluna_src" {
 	includes = {
 		"build",
 		"src",
-		"3rd/lua",
 		"3rd",
+		"3rd/lua",
 		"3rd/yoga",
 		"3rd/zlib",
+		"3rd/soloud/include",
 	},
 	clang = {
 		sources = lm.os == "macos" and {
@@ -52,6 +53,7 @@ lm:source_set "soluna_src" {
 			"-x objective-c",
 		},
 		frameworks = lm.os == "macos" and {
+			"AudioToolbox",
 			"IOKit",
 			"CoreText",
 			"CoreFoundation",

--- a/make.lua
+++ b/make.lua
@@ -87,6 +87,7 @@ lm:conf {
 			"-pthread",
 			"-fPIC",
 			"--use-port=emdawnwebgpu",
+			"-s USE_SDL=2",
 		},
 		links = {
 			"idbfs.js",
@@ -99,6 +100,7 @@ lm:conf {
 			"-s FORCE_FILESYSTEM=1",
 			'-s EXPORTED_RUNTIME_METHODS=\'["FS","FS_createPath","FS_createDataFile","IDBFS"]\'',
 			"-s USE_PTHREADS=1",
+			"-s USE_SDL=2",
 			"-s PTHREAD_POOL_SIZE='Math.max(2,navigator.hardwareConcurrency)'",
 			"-s PTHREAD_POOL_SIZE_STRICT=2",
 			lm.mode == "debug" and "-s ASSERTIONS=2",

--- a/src/soloudone.cpp
+++ b/src/soloudone.cpp
@@ -37,7 +37,15 @@
 
 #endif
 
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 #include "backend/winmm/soloud_winmm.cpp"
+#elif defined(__APPLE__)
+#include "backend/coreaudio/soloud_coreaudio.cpp"
+#elif defined(__linux__)
+#include "backend/alsa/soloud_alsa.cpp"
+#elif defined(__EMSCRIPTEN__)
+#include "backend/sdl2_static/soloud_sdl2_static.cpp"
+#endif
 
 extern "C" {
 #include "audiosource/wav/stb_vorbis.c"


### PR DESCRIPTION
- 验证 macOS
- 手头没有 Linux Desktop 暂时没验证 Linux
- WASM 版有个两个问题是
  1. 浏览器要求通过用户行为触发播放权限获取
  2. audio.init 要在主线程进行. 目前这样直接线程启动会报错:  Cannot read properties of undefined (reading 'audioContext'). 我不确定播放要不要
- 发现 MSVC 编译报错, 大概跟这个有关系: https://github.com/jarikomppa/soloud/pull/341
> 3rd/soloud/src\audiosource/wav/stb_vorbis.c(5089): error C2664: 'int Soloud_Filehack_fopen_s(Soloud_Filehack **,const char *,char *)': cannot convert argument 3 from 'const char [3]' to 'char *'

https://yuchanns.github.io/soluna/examples/audio/

