### PR TITLE
feat(audio): support sound manipulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 bin
 build
+compile_commands.json
+.cache
 node_modules
 .pnpm-store
 pnpm-debug.log*

--- a/asset/sounds.dl
+++ b/asset/sounds.dl
@@ -1,3 +1,12 @@
 --
 name : bloop
 filename : asset/sounds/bloop_x.wav
+
+--
+name : bloop_loop
+filename : asset/sounds/bloop_x.wav
+group : music
+volume : 0.6
+pitch : 0.8
+loop : true
+stream : true

--- a/docs/soluna.lua
+++ b/docs/soluna.lua
@@ -12,6 +12,95 @@
 --- Sprite bundle mapping sprite names to IDs
 ---@alias SpriteBundle table<string, Sprite?>
 
+--- Audio playback options
+---
+--- Values provided here override defaults from `sounds.dl`.
+--- `stream = true` is intended for long-running audio such as background music.
+---
+---@class soluna.AudioPlayOptions
+---@field group? string Audio bus name
+---@field volume? number Linear volume multiplier
+---@field pan? number Stereo pan in range `[-1.0, 1.0]`
+---@field pitch? number Pitch multiplier
+---@field loop? boolean Whether playback should loop
+---@field stream? boolean Whether to stream instead of fully decoding up front
+
+--- Audio voice handle returned by `soluna.play_sound()`
+---
+--- Represents one active playback instance.
+--- When a voice finishes naturally, `:playing()` returns `false`.
+--- Mutating methods return `false` when the voice is no longer valid.
+---
+---@class soluna.AudioVoice
+local AudioVoice = {}
+
+---
+--- Stops playback
+---
+---@param fade_seconds? number Optional fade-out duration in seconds
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:stop(fade_seconds) end
+
+---
+--- Checks whether the voice is still playing
+---
+---@return boolean playing
+function AudioVoice:playing() end
+
+---
+--- Sets voice volume
+---
+---@param volume number Linear volume multiplier
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:set_volume(volume) end
+
+---
+--- Sets voice pan
+---
+---@param pan number Stereo pan in range `[-1.0, 1.0]`
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:set_pan(pan) end
+
+---
+--- Sets voice pitch
+---
+---@param pitch number Pitch multiplier
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:set_pitch(pitch) end
+
+---
+--- Enables or disables looping
+---
+---@param loop boolean
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:set_loop(loop) end
+
+---
+--- Seeks to a playback position in seconds
+---
+---@param seconds number Target playback time in seconds
+---@return boolean ok False when the voice is no longer valid
+function AudioVoice:seek(seconds) end
+
+---
+--- Returns the current playback position in seconds
+---
+---@return number? seconds Current playback time
+---@return string? err Error message when the voice is no longer valid
+function AudioVoice:tell() end
+
+--- Audio bus handle returned by `soluna.audio_bus()`
+---
+---@class soluna.AudioBus
+local AudioBus = {}
+
+---
+--- Sets bus volume
+---
+---@param volume number Linear volume multiplier
+---@return boolean ok False when the bus name is invalid
+function AudioBus:set_volume(volume) end
+
 ---@class soluna
 local soluna = {}
 
@@ -64,5 +153,51 @@ function soluna.gamedir(name) end
 ---@param filename string Path to sprite definition file (.dl format)
 ---@return SpriteBundle sprites Sprite bundle mapping sprite names to IDs
 function soluna.load_sprites(filename) end
+
+---
+--- Loads audio definitions from a datalist file
+---
+--- Each entry in `sounds.dl` must define:
+--- - `name`
+--- - `filename`
+---
+--- Optional entry fields:
+--- - `group` (defaults to `"sound"`)
+--- - `volume`
+--- - `pan`
+--- - `pitch`
+--- - `loop`
+--- - `stream`
+---
+--- `load_sounds()` may be called multiple times. Each bundle registers more sound definitions.
+--- Re-loading the same bundle is ignored. Sound names must stay unique across loaded bundles.
+--- Audio buses are created from the `group` field of loaded sound entries and reused by name.
+---
+---@param filename string Path to audio definition file (.dl format)
+function soluna.load_sounds(filename) end
+
+---
+--- Plays a sound and returns a voice handle
+---
+--- The returned handle represents the active playback instance, not the sound definition.
+--- Background music uses the same API; a typical music entry sets `group = "music"`,
+--- `loop = true`, and `stream = true` in `sounds.dl`.
+---
+---@param name string Sound definition name from `sounds.dl`
+---@param opts? soluna.AudioPlayOptions Per-playback option overrides
+---@return soluna.AudioVoice? voice Active playback handle
+---@return string? err Error message on failure
+function soluna.play_sound(name, opts) end
+
+---
+--- Returns an audio bus handle
+---
+--- Buses are created from the `group` field in loaded `sounds.dl` entries.
+--- When a sound entry omits `group`, it uses the default bus name `"sound"`.
+---
+---@param name string Audio bus name
+---@return soluna.AudioBus? bus Bus handle
+---@return string? err Error message when the bus does not exist
+function soluna.audio_bus(name) end
 
 return soluna

--- a/make.lua
+++ b/make.lua
@@ -162,4 +162,19 @@ lm:dll "sample" {
 
 lm:import "script/act_targets.lua"
 
+lm:runlua "cc" {
+	script = "script/compile_commands.lua",
+	args = {
+		"build/build.ninja",
+		"compile_commands.json",
+	},
+	inputs = {
+		"build/build.ninja",
+		"script/compile_commands.lua",
+	},
+	outputs = {
+		"compile_commands.json",
+	},
+}
+
 lm:default "soluna"

--- a/script/compile_commands.lua
+++ b/script/compile_commands.lua
@@ -1,0 +1,26 @@
+local subprocess = require "bee.subprocess"
+
+local ninja_file, output = ...
+
+assert(ninja_file, "missing ninja file path")
+assert(output, "missing output path")
+
+local process = assert(subprocess.spawn {
+	"ninja",
+	"-f",
+	ninja_file,
+	"-t",
+	"compdb",
+	"-x",
+	searchPath = true,
+	stdout = true,
+})
+
+local content = process.stdout:read "a"
+local code = process:wait()
+if code ~= 0 then
+	os.exit(code, true)
+end
+
+local file <close> = assert(io.open(output, "wb"))
+file:write(content)

--- a/src/audio.c
+++ b/src/audio.c
@@ -58,6 +58,66 @@ struct custom_engine {
 	struct custom_vfs vfs;
 };
 
+struct audio_group {
+	ma_sound_group group;
+	int alive;
+};
+
+struct audio_sound {
+	ma_sound sound;
+	int alive;
+};
+
+#define AUDIO_GROUP_METATABLE "SOLUNA_AUDIO_GROUP"
+#define AUDIO_SOUND_METATABLE "SOLUNA_AUDIO_SOUND"
+
+static struct custom_engine *
+check_engine(lua_State *L, int index) {
+	luaL_checktype(L, index, LUA_TLIGHTUSERDATA);
+	return (struct custom_engine *)lua_touserdata(L, index);
+}
+
+static struct audio_group *
+check_group(lua_State *L, int index) {
+	struct audio_group *group = (struct audio_group *)luaL_checkudata(L, index, AUDIO_GROUP_METATABLE);
+	luaL_argcheck(L, group->alive, index, "closed audio group");
+	return group;
+}
+
+static struct audio_sound *
+check_sound(lua_State *L, int index) {
+	struct audio_sound *sound = (struct audio_sound *)luaL_checkudata(L, index, AUDIO_SOUND_METATABLE);
+	luaL_argcheck(L, sound->alive, index, "closed audio sound");
+	return sound;
+}
+
+static int
+push_error(lua_State *L, ma_result r) {
+	lua_pushnil(L);
+	lua_pushstring(L, ma_result_description(r));
+	return 2;
+}
+
+static int
+laudio_group_uninit(lua_State *L) {
+	struct audio_group *group = (struct audio_group *)luaL_checkudata(L, 1, AUDIO_GROUP_METATABLE);
+	if (group->alive) {
+		ma_sound_group_uninit(&group->group);
+		group->alive = 0;
+	}
+	return 0;
+}
+
+static int
+laudio_sound_uninit(lua_State *L) {
+	struct audio_sound *sound = (struct audio_sound *)luaL_checkudata(L, 1, AUDIO_SOUND_METATABLE);
+	if (sound->alive) {
+		ma_sound_uninit(&sound->sound);
+		sound->alive = 0;
+	}
+	return 0;
+}
+
 static ma_result
 zr_open(ma_vfs* pVFS, const char* pFilePath, ma_uint32 openMode, ma_vfs_file* pFile) {
 	struct custom_vfs *vfs = (struct custom_vfs *)pVFS;
@@ -177,45 +237,184 @@ laudio_init(lua_State *L) {
 
 static int
 laudio_deinit(lua_State *L) {
-	luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
-	ma_engine *engine = (ma_engine *)lua_touserdata(L, 1);
-	ma_engine_uninit(engine);
+	struct custom_engine *e = check_engine(L, 1);
+	ma_engine_uninit(&e->engine);
+	ma_resource_manager_uninit(&e->rm);
 
 	return 0;
 }
 
-/*
-// todo : call ma_sound_init_from_file()
+static int
+laudio_group_init(lua_State *L) {
+	struct custom_engine *e = check_engine(L, 1);
+	struct audio_group *group = (struct audio_group *)lua_newuserdatauv(L, sizeof(*group), 0);
+	group->alive = 0;
+	ma_result r = ma_sound_group_init(&e->engine, 0, NULL, &group->group);
+	if (r != MA_SUCCESS) {
+		lua_pop(L, 1);
+		return push_error(L, r);
+	}
+	group->alive = 1;
+	luaL_setmetatable(L, AUDIO_GROUP_METATABLE);
+	return 1;
+}
 
 static int
-laudio_load(lua_State *L) {
+laudio_group_set_volume(lua_State *L) {
+	struct audio_group *group = check_group(L, 1);
+	float volume = (float)luaL_checknumber(L, 2);
+	ma_sound_group_set_volume(&group->group, volume);
 	return 0;
 }
 
 static int
-laudio_unload(lua_State *L) {
-	return 0;
-}
-*/
-
-static int
-laudio_play(lua_State *L) {
-	luaL_checktype(L, 1, LUA_TLIGHTUSERDATA);
-	ma_engine *engine = (ma_engine *)lua_touserdata(L, 1);
+laudio_sound_init(lua_State *L) {
+	struct custom_engine *e = check_engine(L, 1);
 	const char *filename = luaL_checkstring(L, 2);
-	
-	ma_engine_play_sound(engine, filename, NULL);
+	ma_uint32 flags = (ma_uint32)luaL_optinteger(L, 3, 0);
+	struct audio_group *group = NULL;
+	if (!lua_isnoneornil(L, 4)) {
+		group = check_group(L, 4);
+	}
+
+	struct audio_sound *sound = (struct audio_sound *)lua_newuserdatauv(L, sizeof(*sound), 0);
+	sound->alive = 0;
+	ma_result r = ma_sound_init_from_file(&e->engine, filename, flags, group ? &group->group : NULL, NULL, &sound->sound);
+	if (r != MA_SUCCESS) {
+		lua_pop(L, 1);
+		return push_error(L, r);
+	}
+	sound->alive = 1;
+	luaL_setmetatable(L, AUDIO_SOUND_METATABLE);
+	return 1;
+}
+
+static int
+laudio_sound_start(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	ma_result r = ma_sound_start(&sound->sound);
+	if (r != MA_SUCCESS) {
+		return push_error(L, r);
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static int
+laudio_sound_stop(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	ma_result r;
+	if (lua_isnoneornil(L, 2)) {
+		r = ma_sound_stop(&sound->sound);
+	} else {
+		ma_uint64 fade_ms = (ma_uint64)luaL_checkinteger(L, 2);
+		if (fade_ms == 0) {
+			r = ma_sound_stop(&sound->sound);
+		} else {
+			r = ma_sound_stop_with_fade_in_milliseconds(&sound->sound, fade_ms);
+		}
+	}
+	if (r != MA_SUCCESS) {
+		return push_error(L, r);
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static int
+laudio_sound_playing(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	lua_pushboolean(L, ma_sound_is_playing(&sound->sound));
+	return 1;
+}
+
+static int
+laudio_sound_set_volume(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	float volume = (float)luaL_checknumber(L, 2);
+	ma_sound_set_volume(&sound->sound, volume);
 	return 0;
+}
+
+static int
+laudio_sound_set_pan(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	float pan = (float)luaL_checknumber(L, 2);
+	ma_sound_set_pan(&sound->sound, pan);
+	return 0;
+}
+
+static int
+laudio_sound_set_pitch(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	float pitch = (float)luaL_checknumber(L, 2);
+	ma_sound_set_pitch(&sound->sound, pitch);
+	return 0;
+}
+
+static int
+laudio_sound_set_looping(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	int looping = lua_toboolean(L, 2);
+	ma_sound_set_looping(&sound->sound, looping);
+	return 0;
+}
+
+static int
+laudio_sound_seek(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	float seconds = (float)luaL_checknumber(L, 2);
+	ma_result r = ma_sound_seek_to_second(&sound->sound, seconds);
+	if (r != MA_SUCCESS) {
+		return push_error(L, r);
+	}
+	lua_pushboolean(L, 1);
+	return 1;
+}
+
+static int
+laudio_sound_tell(lua_State *L) {
+	struct audio_sound *sound = check_sound(L, 1);
+	float seconds = 0.0f;
+	ma_result r = ma_sound_get_cursor_in_seconds(&sound->sound, &seconds);
+	if (r != MA_SUCCESS) {
+		return push_error(L, r);
+	}
+	lua_pushnumber(L, seconds);
+	return 1;
 }
 
 int
 luaopen_soluna_audio(lua_State *L) {
 	luaL_checkversion(L);
+	if (luaL_newmetatable(L, AUDIO_GROUP_METATABLE)) {
+		lua_pushcfunction(L, laudio_group_uninit);
+		lua_setfield(L, -2, "__gc");
+	}
+	lua_pop(L, 1);
+	if (luaL_newmetatable(L, AUDIO_SOUND_METATABLE)) {
+		lua_pushcfunction(L, laudio_sound_uninit);
+		lua_setfield(L, -2, "__gc");
+	}
+	lua_pop(L, 1);
 	luaL_Reg l[] = {
 		{ "init", laudio_init },
 		{ "init_vfs", laudio_init_vfs },
 		{ "deinit", laudio_deinit },
-		{ "play", laudio_play },
+		{ "group_init", laudio_group_init },
+		{ "group_uninit", laudio_group_uninit },
+		{ "group_set_volume", laudio_group_set_volume },
+		{ "sound_init", laudio_sound_init },
+		{ "sound_uninit", laudio_sound_uninit },
+		{ "sound_start", laudio_sound_start },
+		{ "sound_stop", laudio_sound_stop },
+		{ "sound_playing", laudio_sound_playing },
+		{ "sound_set_volume", laudio_sound_set_volume },
+		{ "sound_set_pan", laudio_sound_set_pan },
+		{ "sound_set_pitch", laudio_sound_set_pitch },
+		{ "sound_set_looping", laudio_sound_set_looping },
+		{ "sound_seek", laudio_sound_seek },
+		{ "sound_tell", laudio_sound_tell },
 		{ NULL, NULL },
 	};
 	luaL_newlib(L, l);

--- a/src/lualib/soluna.lua
+++ b/src/lualib/soluna.lua
@@ -2,7 +2,7 @@ local ltask = require "ltask"
 local app = require "soluna.app"
 local mqueue = require "ltask.mqueue"
 
-global require, error, string, assert, package, setmetatable
+global require, error, string, assert, package, setmetatable, tostring
 
 local soluna = {
 	platform = app.platform
@@ -14,13 +14,13 @@ function soluna.gamepad_init()
 	soluna.gamepad = state
 	local gs = ltask.uniqueservice "gamepad"
 	local S = ltask.dispatch()
-	
+
 	function S._gamepad_update()
 		gamepad.update(state)
 	end
 
 	ltask.call(gs, "register", ltask.self(), "_gamepad_update")
-	
+
 	return state
 end
 
@@ -61,13 +61,13 @@ function soluna.gamedir(name)
 		path = "My Games/"
 	elseif soluna.platform == "macos" or soluna.platform == "linux" then
 		path = ".local/share/"
-  elseif soluna.platform == "wasm" then
-    path = "persistent/games/"
+	elseif soluna.platform == "wasm" then
+		path = "persistent/games/"
 	else
 		error "TODO: support none windows"
 	end
 	path = path .. name
-	return recursion_mkdir(lfs.personaldir() , path)
+	return recursion_mkdir(lfs.personaldir(), path)
 end
 
 function soluna.load_sprites(filename)
@@ -76,26 +76,68 @@ function soluna.load_sprites(filename)
 	return sprites
 end
 
-
 local audio_service
-local audio_sounds = {}
 
-local function fetch_audio_list(_, name)
-	audio_service = audio_service or ltask.uniqueservice "audio"
-	audio_sounds = ltask.call(audio_service, "fetch")
-	return audio_sounds[name]
+local voice_index = {}
+local voice_mt = { __index = voice_index }
+
+function voice_index:stop(fade_seconds)
+	return ltask.call(audio_service, "voice_stop", self.id, fade_seconds)
 end
 
-setmetatable(audio_sounds, { __index = fetch_audio_list })
+function voice_index:playing()
+	return ltask.call(audio_service, "voice_playing", self.id)
+end
+
+function voice_index:set_volume(volume)
+	return ltask.call(audio_service, "voice_set_volume", self.id, volume)
+end
+
+function voice_index:set_pan(pan)
+	return ltask.call(audio_service, "voice_set_pan", self.id, pan)
+end
+
+function voice_index:set_pitch(pitch)
+	return ltask.call(audio_service, "voice_set_pitch", self.id, pitch)
+end
+
+function voice_index:set_loop(loop)
+	return ltask.call(audio_service, "voice_set_loop", self.id, loop)
+end
+
+function voice_index:seek(seconds)
+	return ltask.call(audio_service, "voice_seek", self.id, seconds)
+end
+
+function voice_index:tell()
+	return ltask.call(audio_service, "voice_tell", self.id)
+end
+
+local bus_index = {}
+local bus_mt = { __index = bus_index }
+
+function bus_index:set_volume(volume)
+	return ltask.call(audio_service, "bus_set_volume", self.name, volume)
+end
 
 function soluna.load_sounds(filename)
 	audio_service = audio_service or ltask.uniqueservice "audio"
 	ltask.call(audio_service, "init", filename)
 end
 
-function soluna.play_sound(name)
-	local id = audio_sounds[name]
-	ltask.send(audio_service, true, id)
+function soluna.play_sound(name, opts)
+	local id, err = ltask.call(audio_service, "play_sound", name, opts)
+	if not id then
+		return nil, err
+	end
+	return setmetatable({ id = id }, voice_mt)
+end
+
+function soluna.audio_bus(name)
+	if not ltask.call(audio_service, "has_bus", name) then
+		return nil, "Unknown audio bus " .. tostring(name)
+	end
+	return setmetatable({ name = name }, bus_mt)
 end
 
 function soluna.preload(spr)

--- a/src/service/audio.lua
+++ b/src/service/audio.lua
@@ -3,66 +3,294 @@ local audio = require "soluna.audio"
 local file = require "soluna.file"
 local datalist = require "soluna.datalist"
 
-global print, assert, setmetatable, tostring, error, ipairs
+global assert, error, ipairs, math, pairs, tonumber, tostring
 
-local DEVICE, BANK, MAP
+local device
+local definitions = {}
+local groups = {}
+local voices = {}
+local bundles = {}
+local next_voice_id_value = 0
+local ziplist
+local is_quit
 
-local api = {}
+local SOUND_FLAG_STREAM = 0x00000001
+local DEFAULT_DEFINITION = {
+	group = "sound",
+	volume = 1.0,
+	pan = 0.0,
+	pitch = 1.0,
+	loop = false,
+	stream = false,
+}
 
-local play = audio.play
-
--- play
-api[true] = function(id)
-	play(DEVICE, BANK[id])
-end
-
-local S = {}
-
-global type, tonumber, error, assert, ipairs, print, pairs
-
-for k in pairs(api) do
-	S[k] = function()
-		error "Init audio first"
+local function convert_value(v)
+	if v == "true" then
+		return true
 	end
+	if v == "false" then
+		return false
+	end
+	return tonumber(v) or v
 end
 
 local function load_bundle(filename)
-	local b = datalist.parse(file.load(filename))
-	local bank = {}
-	local map = {}
-	for i, v in ipairs(b) do
-		bank[i] = assert(v.filename)
-		map[assert(v.name)] = i
+	local source = file.load(filename)
+	local bundle = datalist.parse(assert(source, "Can't load audio bundle " .. tostring(filename)))
+	local defs = {}
+	for _, v in ipairs(bundle) do
+		local def = {
+			group = DEFAULT_DEFINITION.group,
+			volume = DEFAULT_DEFINITION.volume,
+			pan = DEFAULT_DEFINITION.pan,
+			pitch = DEFAULT_DEFINITION.pitch,
+			loop = DEFAULT_DEFINITION.loop,
+			stream = DEFAULT_DEFINITION.stream,
+		}
+		for k, value in pairs(v) do
+			def[k] = convert_value(value)
+		end
+		def.name = assert(def.name)
+		def.filename = assert(def.filename)
+		if defs[def.name] then
+			error("Duplicate sound " .. tostring(def.name))
+		end
+		defs[def.name] = def
 	end
-	return bank, map
+	return defs
 end
 
-local ziplist
+local function merge_definition(def, opts)
+	if opts == nil then
+		return {
+			filename = def.filename,
+			group = def.group,
+			volume = def.volume,
+			pan = def.pan,
+			pitch = def.pitch,
+			loop = def.loop,
+			stream = def.stream,
+		}
+	end
+	local loop = opts.loop
+	if loop == nil then
+		loop = def.loop
+	end
+	local stream = opts.stream
+	if stream == nil then
+		stream = def.stream
+	end
+	return {
+		filename = def.filename,
+		group = opts.group ~= nil and opts.group or def.group,
+		volume = opts.volume ~= nil and opts.volume or def.volume,
+		pan = opts.pan ~= nil and opts.pan or def.pan,
+		pitch = opts.pitch ~= nil and opts.pitch or def.pitch,
+		loop = loop,
+		stream = stream,
+	}
+end
 
-function S.init_device(device)
+local function release_voice(id)
+	local voice = voices[id]
+	if not voice then
+		return
+	end
+	audio.sound_uninit(voice)
+	voices[id] = nil
+end
+
+local function cleanup_voices()
+	for id, voice in pairs(voices) do
+		if not audio.sound_playing(voice) then
+			release_voice(id)
+		end
+	end
+end
+
+local function next_voice_id()
+	next_voice_id_value = next_voice_id_value + 1
+	return next_voice_id_value
+end
+
+local function seconds_to_ms(seconds)
+	if seconds == nil then
+		return nil
+	end
+	if seconds <= 0 then
+		return 0
+	end
+	return math.floor(seconds * 1000 + 0.5)
+end
+
+ltask.fork(function()
+	while not is_quit do
+		cleanup_voices()
+		ltask.sleep(20)
+	end
+end)
+
+local S = {}
+
+function S.init_device(dev)
 	ziplist = file.ziplist and file.ziplist()
 	if ziplist then
-		audio.init_vfs(device, ziplist)
+		audio.init_vfs(dev, ziplist)
 	end
-	DEVICE = device
+	device = dev
 end
 
 function S.init(filename)
-	assert(BANK == nil)
-	BANK, MAP = load_bundle(filename)
-	-- todo : preload file list
-	local inject = ltask.dispatch()
-	for k, v in pairs(api) do
-		inject[k] = v
+	if bundles[filename] then
+		return
 	end
+	local defs = load_bundle(filename)
+	for name, def in pairs(defs) do
+		if definitions[name] then
+			error("Duplicate sound " .. tostring(name))
+		end
+		local group = groups[def.group]
+		if group == nil then
+			group = assert(audio.group_init(device))
+			groups[def.group] = group
+		end
+		definitions[name] = def
+	end
+	bundles[filename] = true
 end
 
-function S.fetch()
-	return MAP or "Init audio file list first"
+function S.play_sound(name, opts)
+	local def = definitions[name]
+	if def == nil then
+		return nil, "Unknown sound " .. tostring(name)
+	end
+
+	local final = merge_definition(def, opts)
+	local group = groups[final.group]
+	if group == nil then
+		return nil, "Unknown audio bus " .. tostring(final.group)
+	end
+
+	local flags = final.stream and SOUND_FLAG_STREAM or 0
+
+	local voice, err = audio.sound_init(device, final.filename, flags, group)
+	if not voice then
+		return nil, err
+	end
+
+	audio.sound_set_volume(voice, final.volume)
+	audio.sound_set_pan(voice, final.pan)
+	audio.sound_set_pitch(voice, final.pitch)
+	audio.sound_set_looping(voice, final.loop == true)
+
+	local ok, start_err = audio.sound_start(voice)
+	if not ok then
+		audio.sound_uninit(voice)
+		return nil, start_err
+	end
+
+	local id = next_voice_id()
+	voices[id] = voice
+	return id
+end
+
+function S.has_bus(name)
+	return groups[name] ~= nil
+end
+
+function S.voice_stop(id, fade_seconds)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	return audio.sound_stop(voice, seconds_to_ms(fade_seconds)) ~= nil
+end
+
+function S.voice_playing(id)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	local playing = audio.sound_playing(voice)
+	if not playing then
+		release_voice(id)
+	end
+	return playing
+end
+
+function S.voice_set_volume(id, volume)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	audio.sound_set_volume(voice, volume)
+	return true
+end
+
+function S.voice_set_pan(id, pan)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	audio.sound_set_pan(voice, pan)
+	return true
+end
+
+function S.voice_set_pitch(id, pitch)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	audio.sound_set_pitch(voice, pitch)
+	return true
+end
+
+function S.voice_set_loop(id, loop)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	audio.sound_set_looping(voice, loop)
+	return true
+end
+
+function S.voice_seek(id, seconds)
+	local voice = voices[id]
+	if not voice then
+		return false
+	end
+	return audio.sound_seek(voice, seconds) ~= nil
+end
+
+function S.voice_tell(id)
+	local voice = voices[id]
+	if not voice then
+		return nil, "Voice not found"
+	end
+	return audio.sound_tell(voice)
+end
+
+function S.bus_set_volume(name, volume)
+	local group = groups[name]
+	if group == nil then
+		return false
+	end
+	audio.group_set_volume(group, volume)
+	return true
 end
 
 function S.quit()
-	DEVICE = nil
+	is_quit = true
+	for id in pairs(voices) do
+		release_voice(id)
+	end
+	for name, group in pairs(groups) do
+		audio.group_uninit(group)
+		groups[name] = nil
+	end
+	device = nil
+	definitions = {}
+	bundles = {}
 end
 
 return S

--- a/test/audio.game
+++ b/test/audio.game
@@ -1,0 +1,1 @@
+entry : test/audio.lua

--- a/test/audio.lua
+++ b/test/audio.lua
@@ -12,13 +12,39 @@ local batch = args.batch
 local screen_w = args.width
 local screen_h = args.height
 
-local BUTTON_W <const> = 180
-local BUTTON_H <const> = 64
+local sound_bus = assert(soluna.audio_bus "sound")
+local music_bus = assert(soluna.audio_bus "music")
+
+local BUTTON_W <const> = 220
+local BUTTON_H <const> = 56
+local BUTTON_GAP <const> = 18
+local BUTTON_COLS <const> = 2
+local BUTTON_ROWS <const> = 5
 local SHADOW_Y <const> = 6
+local BUTTON_TEXT_COLOR <const> = 0xff28435c
+local STATUS_TEXT_COLOR <const> = 0xffdce7f2
+
+local BUTTON_PLAY_SHOT <const> = 1
+local BUTTON_TOGGLE_LOOP <const> = 2
+local BUTTON_STOP_LAST <const> = 3
+local BUTTON_STOP_LOOP <const> = 4
+local BUTTON_SEEK_START <const> = 5
+local BUTTON_SEEK_STEP <const> = 6
+local BUTTON_SOUND_DOWN <const> = 7
+local BUTTON_SOUND_UP <const> = 8
+local BUTTON_MUSIC_DOWN <const> = 9
+local BUTTON_MUSIC_UP <const> = 10
 
 local pointer_x = screen_w // 2
 local pointer_y = screen_h // 2
 local pressed = false
+local pressed_button
+
+local sound_volume = 1.0
+local music_volume = 1.0
+local last_voice
+local loop_voice
+local loop_time = 0.0
 
 local function load_font(data, name)
 	if not data then
@@ -52,17 +78,145 @@ local function font_init()
 	error "No available system font for audio sample"
 end
 
-local play_label = mattext.block(font.cobj(), font_init(), 28, 0xff28435c, "C")("Play", BUTTON_W, BUTTON_H)
+local fontid = font_init()
+local button_text = mattext.block(font.cobj(), fontid, 24, BUTTON_TEXT_COLOR, "CV")
+local info_text = mattext.block(font.cobj(), fontid, 20, STATUS_TEXT_COLOR, "L")
+
+local labels = {
+	[BUTTON_PLAY_SHOT] = button_text("Play Shot", BUTTON_W, BUTTON_H),
+	[BUTTON_TOGGLE_LOOP] = button_text("Toggle Loop", BUTTON_W, BUTTON_H),
+	[BUTTON_STOP_LAST] = button_text("Stop Last Voice", BUTTON_W, BUTTON_H),
+	[BUTTON_STOP_LOOP] = button_text("Stop Loop Voice", BUTTON_W, BUTTON_H),
+	[BUTTON_SEEK_START] = button_text("Seek Loop 0.00", BUTTON_W, BUTTON_H),
+	[BUTTON_SEEK_STEP] = button_text("Seek Loop +0.20", BUTTON_W, BUTTON_H),
+	[BUTTON_SOUND_DOWN] = button_text("Sound -", BUTTON_W, BUTTON_H),
+	[BUTTON_SOUND_UP] = button_text("Sound +", BUTTON_W, BUTTON_H),
+	[BUTTON_MUSIC_DOWN] = button_text("Music -", BUTTON_W, BUTTON_H),
+	[BUTTON_MUSIC_UP] = button_text("Music +", BUTTON_W, BUTTON_H),
+}
+
+local function clamp(v, lo, hi)
+	if v < lo then
+		return lo
+	elseif v > hi then
+		return hi
+	end
+	return v
+end
+
+local function playing(voice)
+	return voice ~= nil and voice:playing()
+end
 
 local function update_pointer(x, y)
 	pointer_x = x
 	pointer_y = y
 end
 
-local function inside_button(x, y)
-	local bx = (screen_w - BUTTON_W) // 2
-	local by = (screen_h - BUTTON_H) // 2
-	return x >= bx and x <= bx + BUTTON_W and y >= by and y <= by + BUTTON_H
+local function button_rect(index)
+	local total_w = BUTTON_COLS * BUTTON_W + (BUTTON_COLS - 1) * BUTTON_GAP
+	local total_h = BUTTON_ROWS * BUTTON_H + (BUTTON_ROWS - 1) * BUTTON_GAP
+	local origin_x = (screen_w - total_w) // 2
+	local origin_y = (screen_h - total_h) // 2 - 40
+	local col = (index - 1) % BUTTON_COLS
+	local row = (index - 1) // BUTTON_COLS
+	return origin_x + col * (BUTTON_W + BUTTON_GAP), origin_y + row * (BUTTON_H + BUTTON_GAP)
+end
+
+local function button_at(x, y)
+	for i = 1, BUTTON_ROWS * BUTTON_COLS do
+		local bx, by = button_rect(i)
+		if x >= bx and x <= bx + BUTTON_W and y >= by and y <= by + BUTTON_H then
+			return i
+		end
+	end
+end
+
+local function click_button(index)
+	if index == BUTTON_PLAY_SHOT then
+		last_voice = assert(soluna.play_sound("bloop", {
+			volume = 0.25,
+			pan = clamp(pointer_x / screen_w * 2.0 - 1.0, -1.0, 1.0),
+			pitch = 0.95,
+		}))
+		return
+	end
+
+	if index == BUTTON_TOGGLE_LOOP then
+		local voice = loop_voice
+		if playing(voice) then
+			voice:stop(0.1)
+			if loop_voice == voice then
+				loop_voice = nil
+			end
+		else
+			loop_voice = assert(soluna.play_sound "bloop_loop")
+		end
+		return
+	end
+
+	if index == BUTTON_STOP_LAST then
+		local voice = last_voice
+		if voice then
+			voice:stop()
+			if last_voice == voice then
+				last_voice = nil
+			end
+		end
+		return
+	end
+
+	if index == BUTTON_STOP_LOOP then
+		local voice = loop_voice
+		if voice then
+			voice:stop(0.1)
+			if loop_voice == voice then
+				loop_voice = nil
+				loop_time = 0.0
+			end
+		end
+		return
+	end
+
+	if index == BUTTON_SEEK_START then
+		local voice = loop_voice
+		if voice then
+			voice:seek(0.0)
+		end
+		return
+	end
+
+	if index == BUTTON_SEEK_STEP then
+		local voice = loop_voice
+		if voice then
+			local now = voice:tell() or 0.0
+			voice:seek(now + 0.2)
+		end
+		return
+	end
+
+	if index == BUTTON_SOUND_DOWN then
+		sound_volume = clamp(sound_volume - 0.1, 0.0, 1.0)
+		sound_bus:set_volume(sound_volume)
+		return
+	end
+
+	if index == BUTTON_SOUND_UP then
+		sound_volume = clamp(sound_volume + 0.1, 0.0, 1.0)
+		sound_bus:set_volume(sound_volume)
+		return
+	end
+
+	if index == BUTTON_MUSIC_DOWN then
+		music_volume = clamp(music_volume - 0.1, 0.0, 1.0)
+		music_bus:set_volume(music_volume)
+		return
+	end
+
+	if index == BUTTON_MUSIC_UP then
+		music_volume = clamp(music_volume + 0.1, 0.0, 1.0)
+		music_bus:set_volume(music_volume)
+	end
 end
 
 local callback = {}
@@ -81,46 +235,91 @@ function callback.mouse_button(button, key_state)
 		return
 	end
 	if key_state == 1 then
-		pressed = inside_button(pointer_x, pointer_y)
+		pressed_button = button_at(pointer_x, pointer_y)
+		pressed = pressed_button ~= nil
 		return
 	end
-	if pressed and inside_button(pointer_x, pointer_y) then
-		soluna.play_sound "bloop"
+	local index = button_at(pointer_x, pointer_y)
+	if pressed and index == pressed_button then
+		click_button(index)
 	end
 	pressed = false
+	pressed_button = nil
 end
 
 function callback.touch_begin(x, y)
 	update_pointer(x, y)
-	pressed = inside_button(x, y)
+	pressed_button = button_at(x, y)
+	pressed = pressed_button ~= nil
 end
 
 function callback.touch_moved(x, y)
 	update_pointer(x, y)
-	pressed = inside_button(x, y)
+	if button_at(x, y) ~= pressed_button then
+		pressed = false
+	end
 end
 
 function callback.touch_end(x, y)
 	update_pointer(x, y)
-	if pressed and inside_button(x, y) then
-		soluna.play_sound "bloop"
+	local index = button_at(x, y)
+	if pressed and index == pressed_button then
+		click_button(index)
 	end
 	pressed = false
+	pressed_button = nil
 end
 
 function callback.touch_cancelled()
 	pressed = false
+	pressed_button = nil
 end
 
 function callback.frame()
-	local bx = (screen_w - BUTTON_W) // 2
-	local by = (screen_h - BUTTON_H) // 2
-	local hovered = inside_button(pointer_x, pointer_y)
-	local face_y = by + (pressed and 4 or 0)
-	local color = pressed and 0xffcfd8e4 or hovered and 0xfffbfdff or 0xffeef3f8
-	batch:add(matquad.quad(BUTTON_W, BUTTON_H, 0xff7389a3), bx, by + SHADOW_Y)
-	batch:add(matquad.quad(BUTTON_W, BUTTON_H, color), bx, face_y)
-	batch:add(play_label, bx, face_y)
+	local last = last_voice
+	local loop = loop_voice
+	local last_playing = playing(last)
+	local loop_playing = playing(loop)
+
+	if loop_playing then
+		loop_time = loop:tell() or loop_time
+	else
+		loop_time = 0.0
+	end
+
+	local title = info_text("Audio API Sample", 400, 28)
+	local subtitle = info_text("Play voices, seek a stream voice, and adjust sound/music buses.", 640, 24)
+	local status_1 = info_text(
+		string.format("sound bus %.1f  |  music bus %.1f", sound_volume, music_volume),
+		480,
+		24
+	)
+	local status_2 = info_text(
+		string.format(
+			"last voice %s  |  loop voice %s  |  loop time %.2f",
+			last_playing and "playing" or "idle",
+			loop_playing and "playing" or "idle",
+			loop_time
+		),
+		640,
+		24
+	)
+
+	batch:add(title, (screen_w - 400) // 2, 40)
+	batch:add(subtitle, (screen_w - 640) // 2, 72)
+	batch:add(status_1, (screen_w - 480) // 2, screen_h - 90)
+	batch:add(status_2, (screen_w - 640) // 2, screen_h - 62)
+
+	for i = 1, BUTTON_ROWS * BUTTON_COLS do
+		local bx, by = button_rect(i)
+		local hovered = button_at(pointer_x, pointer_y) == i
+		local active = pressed and pressed_button == i
+		local face_y = by + (active and 4 or 0)
+		local face_color = active and 0xffcfd8e4 or hovered and 0xfffbfdff or 0xffeef3f8
+		batch:add(matquad.quad(BUTTON_W, BUTTON_H, 0xff7389a3), bx, by + SHADOW_Y)
+		batch:add(matquad.quad(BUTTON_W, BUTTON_H, face_color), bx, face_y)
+		batch:add(labels[i], bx, face_y)
+	end
 end
 
 return callback


### PR DESCRIPTION
写 https://yuchanns.github.io/soluna_examples/games/geometry_wars/ 的时候想着把音量也加上，所以就试着扩展了 audio 的功能

- 扩展 `soluna.play_sound` 实现, 返回一个 handle, 可以进行 stop / playing / set_volume / set_pan / set_pitch /
     set_loop / seek / tell
- 增加了 audio bus 概念, 可以从配置文件里通过 group 字段自定义 bus, 按 bus 进行音量控制. 
- 更新了 audio 测试
- 增加了 audio api 文档

声音配置文件扩展支持的参数如下:
```
--
name : bloop
filename : asset/sounds/bloop_x.wav
group : sound
volume : 1.0
pan : 0.0
pitch : 1.0
loop : false

--
name : bloop_loop
filename : asset/sounds/bloop_x.wav
group : music
volume : 0.6
pan : 0.0
pitch : 0.8
loop : true
stream : true
```