### PR TITLE
fix(wasm): sample ext material

### DIFF
--- a/extlua/extlua_sample.c
+++ b/extlua/extlua_sample.c
@@ -1,6 +1,5 @@
 #include <lua.h>
 #include <lauxlib.h>
-#include <math.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -18,14 +17,15 @@ void materialapi_init(lua_State *L);
 
 #define PQUAD_CORNER_N 4
 #define PQUAD_EPSILON 0.000001f
+#define PQUAD_DEPTH 460.0f
 
 struct color {
 	unsigned char channel[4];
 };
 
 struct pquad_payload {
-	float angle;
-	float depth;
+	float sin_angle;
+	float cos_angle;
 	struct color color;
 };
 
@@ -111,10 +111,10 @@ submit_perspective_quad(const struct material_item *item, void *out) {
 		return "Perspective quad needs a sprite";
 	}
 	const struct pquad_payload *payload = (const struct pquad_payload *)item->data;
-	float depth = payload->depth > PQUAD_EPSILON ? payload->depth : 460.0f;
+	float depth = PQUAD_DEPTH;
 	float focal = depth;
-	float c = cosf(payload->angle);
-	float s = sinf(payload->angle);
+	float s = payload->sin_angle;
+	float c = payload->cos_angle;
 	float pos[PQUAD_CORNER_N][2];
 	struct pquad_inst *inst = (struct pquad_inst *)out;
 	int corner;
@@ -180,8 +180,8 @@ lperspective_quad_sprite(lua_State *L) {
 	luaL_checktype(L, 2, LUA_TTABLE);
 	struct pquad_payload payload;
 	memset(&payload, 0, sizeof(payload));
-	payload.angle = get_number_field(L, 2, "angle", 0.0f);
-	payload.depth = get_number_field(L, 2, "depth", 460.0f);
+	payload.sin_angle = get_number_field(L, 2, "sin_angle", 0.0f);
+	payload.cos_angle = get_number_field(L, 2, "cos_angle", 1.0f);
 	payload.color = get_color(L, 2);
 	int sprite = luaL_checkinteger(L, 1) - 1;
 	struct material_push_item item = {

--- a/test/extlua.lua
+++ b/test/extlua.lua
@@ -87,14 +87,21 @@ end
 
 local sprites = make_card_sprite()
 local card = assert(sprites.card)
+local screen_w = args.width
+local screen_h = args.height
+
+function callback.window_resize(w, h)
+	screen_w = w
+	screen_h = h
+end
 
 function callback.frame(count)
 	local theta = math.sin(count * 0.021) * 1.15
 	batch:add(matpq.sprite(card, {
-		angle = theta,
-		depth = 460.0,
+		sin_angle = math.sin(theta),
+		cos_angle = math.cos(theta),
 		color = WHITE,
-	}), args.width * 0.5, args.height * 0.5)
+	}), screen_w * 0.5, screen_h * 0.5)
 end
 
 return callback


### PR DESCRIPTION
修复 MAIN_MODULE=2 (瘦身) 没有导出数学库给 SIDE MODULE 用, 导致 WASM 的 sample 示例错误的问题。