### PR TITLE
feat(text): add no-break wrap groups

### DIFF
--- a/docs/material_text.lua
+++ b/docs/material_text.lua
@@ -101,12 +101,17 @@ end
 ---Text material module.
 ---
 ---Tagged text stream 支持 `[i42]` icon、`[hex]` 临时颜色、`[sN]` style 切换、
----`[s]` 回到 style 0，以及 `[[` 输出字面量 `[`。`[sN]` 中的 `N` 是
----0-based style id，Lua style 数组第一项对应 style 0。
+---`[s]` 回到 style 0、`[wN]` / `[w]` 标记不可拆分换行组，以及 `[[`
+---输出字面量 `[`。`[sN]` 中的 `N` 是 0-based style id，Lua style 数组
+---第一项对应 style 0。`[wN]` 中的 `N` 是调用方自定义的正整数 group id；
+---group 本身比行宽更宽时会退回普通逐字换行。
 ---
 ---Tagged text streams support `[i42]` icons, `[hex]` temporary colors, `[sN]`
----style switching, `[s]` reset to style 0, and `[[` for a literal `[`.
----`N` in `[sN]` is a 0-based style id. The first Lua style entry is style 0.
+---style switching, `[s]` reset to style 0, `[wN]` / `[w]` no-break wrap
+---groups, and `[[` for a literal `[`. `N` in `[sN]` is a 0-based style id.
+---The first Lua style entry is style 0. `N` in `[wN]` is a caller-defined
+---positive group id. A group wider than the line falls back to normal
+---per-character wrapping.
 ---@class soluna.material.text
 local mattext = {}
 

--- a/src/material_text.c
+++ b/src/material_text.c
@@ -658,7 +658,7 @@ tohex(char c) {
 }
 
 static const char *
-parse_bracket(struct block_context *ctx, const char *str, int *icon) {
+parse_bracket(struct block_context *ctx, const char *str, int *icon, int *group) {
 	char c = *str;
 	int hex = -1;
 	if (c == 'i') {
@@ -698,9 +698,114 @@ parse_bracket(struct block_context *ctx, const char *str, int *icon) {
 	} else if (c == 'n') {
 		ctx->fs = &ctx->s->s[0];
 		ctx->color = ctx->fs->color;
+	} else if (c == 'w') {
+		++str;
+		int word_group = 0;
+		while (*str >= '0' && *str <= '9') {
+			word_group = word_group * 10 + (*str - '0');
+			++str;
+		}
+		*group = word_group;
 	}
 	// todo: other command
 	return skip_bracket(str);
+}
+
+enum text_token_type {
+	TEXT_TOKEN_END,
+	TEXT_TOKEN_GROUP,
+	TEXT_TOKEN_NEWLINE,
+	TEXT_TOKEN_SPACE,
+	TEXT_TOKEN_GLYPH,
+};
+
+struct text_token {
+	enum text_token_type type;
+	int advance_x;
+	int dy;
+	int codepoint;
+	int font;
+};
+
+static const char *
+next_text_token(const char *str, struct block_context *ctx, int *group,
+	struct text_token *token) {
+	struct font_manager *mgr = ctx->s->font;
+	for (;;) {
+		uint32_t val = 0;
+		str = utf8_decode(str, &val);
+		if (str == NULL || val == 0) {
+			token->type = TEXT_TOKEN_END;
+			return str;
+		}
+		if (val <= 32) {
+			if (val == '\n') {
+				token->type = TEXT_TOKEN_NEWLINE;
+				return str;
+			}
+			struct font_glyph g, og;
+			if (font_manager_glyph(mgr, ctx->fs->fontid, ' ', ctx->fs->size, &g, &og) == NULL) {
+				token->type = TEXT_TOKEN_SPACE;
+				token->advance_x = g.advance_x;
+				return str;
+			}
+			continue;
+		}
+
+		int icon = 0;
+		if (val == '[') {
+			if (*str != '[') {
+				int previous_group = *group;
+				str = parse_bracket(ctx, str, &icon, group);
+				if (*group != previous_group) {
+					token->type = TEXT_TOKEN_GROUP;
+					return str;
+				}
+				if (!icon)
+					continue;
+			} else {
+				++str;
+			}
+		}
+
+		int codepoint = val;
+		int font = ctx->fs->fontid;
+		int dy = 0;
+		if (icon > 0) {
+			codepoint = icon - 1;
+			font = FONT_ICON;
+			dy = -ctx->fs->ascent;
+		}
+		struct font_glyph g, og;
+		if (font_manager_glyph(mgr, font, codepoint, ctx->fs->size, &g, &og) == NULL) {
+			token->type = TEXT_TOKEN_GLYPH;
+			token->advance_x = g.advance_x;
+			token->dy = dy;
+			token->codepoint = codepoint;
+			token->font = font;
+			return str;
+		}
+	}
+}
+
+static int
+measure_word_group(const char *str, struct block_context *ctx, int group) {
+	struct block_context probe = *ctx;
+	int current_group = group;
+	int width = 0;
+	for (;;) {
+		struct text_token token;
+		str = next_text_token(str, &probe, &current_group, &token);
+		if (token.type == TEXT_TOKEN_END || token.type == TEXT_TOKEN_GROUP ||
+			token.type == TEXT_TOKEN_NEWLINE)
+			break;
+		if (token.type == TEXT_TOKEN_SPACE || token.type == TEXT_TOKEN_GLYPH) {
+			width += token.advance_x;
+			if (width > probe.width)
+				break;
+		}
+	}
+	return width;
 }
 
 static int
@@ -713,7 +818,6 @@ ltext_(lua_State *L, struct styles *s, int gen_layout, int external) {
 	ctx.width = luaL_optinteger(L, 2, MAX_WIDTH);
 	ctx.height = luaL_optinteger(L, 3, MAX_HEIGHT);
 
-	struct font_manager *mgr = s->font;
 	ctx.x = 0;
 	ctx.color = s->s[0].color;
 	ctx.y = 0;
@@ -724,7 +828,6 @@ ltext_(lua_State *L, struct styles *s, int gen_layout, int external) {
 	ctx.line_height = 0;
 	ctx.alignment = lua_tointeger(L, lua_upvalueindex(5));
 
-	char * buffer = NULL;
 	struct text_primitive * prim = NULL;
 	struct layout * pos = NULL;
 	if (gen_layout) {
@@ -739,88 +842,76 @@ ltext_(lua_State *L, struct styles *s, int gen_layout, int external) {
 		pos->line_count = 0;
 		set_layout_styles(L, pos, s, external);
 	} else {
-		buffer = (char *)malloc(count * sizeof(struct text_primitive)+1);
-		prim = (struct text_primitive *)buffer;
+		prim = (struct text_primitive *)malloc((size_t)count * sizeof(*prim) + 1);
+		if (prim == NULL)
+			return luaL_error(L, "Out of memory");
 	}
 	int n = 0;
+	int group = 0;
 	for (;;) {
-		uint32_t val = 0;
-		str = utf8_decode(str, &val);
-		if (str == NULL || val == 0)
+		struct text_token token;
+		str = next_text_token(str, &ctx, &group, &token);
+		if (token.type == TEXT_TOKEN_END)
 			break;
-		if (val <= 32) {
-			if (val == '\n') {
-				if (ctx.x > ctx.line_width)
-					ctx.line_width = ctx.x;
-				if (newline(&ctx, prim, n, pos))
-					break;
-			} else {
-				struct font_glyph g, og;
-				if (font_manager_glyph(mgr, ctx.fs->fontid, ' ', ctx.fs->size, &g, &og) == NULL) {
+		if (token.type == TEXT_TOKEN_GROUP) {
+			if (group > 0 && ctx.x > 0) {
+				int group_width = measure_word_group(str, &ctx, group);
+				if (group_width <= ctx.width &&
+					ctx.x + group_width > ctx.width) {
 					if (ctx.x > ctx.line_width)
 						ctx.line_width = ctx.x;
-					if (advance_space(&ctx, prim, pos, &n, g.advance_x))
-						break;
-				}
-			}
-		} else {
-			int icon = 0;
-			if (val == '[') {
-				if (*str != '[') {
-					str = parse_bracket(&ctx, str, &icon);
-					if (!icon) {
-						continue;
-					}
-				} else {
-					++str;
-				}
-			}
-			int dy = 0;
-			int codepoint = val;
-			int font = ctx.fs->fontid;
-			
-			if (icon > 0) {
-				codepoint = icon -1;
-				font = FONT_ICON;
-				
-				dy = - ctx.fs->ascent;
-			}
-			
-			if (prim) {
-				prim[n].pos.x = ctx.x * PIXEL_SCALE;
-				prim[n].pos.y = ( ctx.y + dy ) * PIXEL_SCALE;
-				prim[n].pos.sr = 0;
-				prim[n].pos.sprite = -material_id;
-			} else {
-				// assert(pos != NULL)
-				set_position(pos, n, &ctx);
-			}
-			
-			struct font_glyph g, og;
-			if (font_manager_glyph(mgr, font, codepoint, ctx.fs->size, &g, &og) == NULL) {
-				if (ctx.x > ctx.line_width)
-					ctx.line_width = ctx.x;
-				if (advance(pos, &ctx, g.advance_x)) {
 					if (newline(&ctx, prim, n, pos))
 						break;
-					if (prim) {
-						prim[n].pos.x = ctx.x * PIXEL_SCALE;
-						prim[n].pos.y = ( ctx.y + dy ) * PIXEL_SCALE;
-					} else {
-						set_position(pos, n, &ctx);
-					}
-					advance(pos, &ctx, g.advance_x);
 				}
-				if (prim) {
-					prim[n].u.text.header.sprite = -1;
-					prim[n].u.text.codepoint = codepoint;
-					prim[n].u.text.font = font;
-					prim[n].u.text.size = ctx.fs->size;
-					prim[n].u.text.color = ctx.color;
-				}
-				++n;
 			}
+			continue;
 		}
+		if (token.type == TEXT_TOKEN_NEWLINE) {
+			if (ctx.x > ctx.line_width)
+				ctx.line_width = ctx.x;
+			if (newline(&ctx, prim, n, pos))
+				break;
+			continue;
+		}
+		if (token.type == TEXT_TOKEN_SPACE) {
+			if (ctx.x > ctx.line_width)
+				ctx.line_width = ctx.x;
+			if (advance_space(&ctx, prim, pos, &n, token.advance_x))
+				break;
+			continue;
+		}
+
+		if (prim) {
+			prim[n].pos.x = ctx.x * PIXEL_SCALE;
+			prim[n].pos.y = (ctx.y + token.dy) * PIXEL_SCALE;
+			prim[n].pos.sr = 0;
+			prim[n].pos.sprite = -material_id;
+		} else {
+			// assert(pos != NULL)
+			set_position(pos, n, &ctx);
+		}
+
+		if (ctx.x > ctx.line_width)
+			ctx.line_width = ctx.x;
+		if (advance(pos, &ctx, token.advance_x)) {
+			if (newline(&ctx, prim, n, pos))
+				break;
+			if (prim) {
+				prim[n].pos.x = ctx.x * PIXEL_SCALE;
+				prim[n].pos.y = (ctx.y + token.dy) * PIXEL_SCALE;
+			} else {
+				set_position(pos, n, &ctx);
+			}
+			advance(pos, &ctx, token.advance_x);
+		}
+		if (prim) {
+			prim[n].u.text.header.sprite = -1;
+			prim[n].u.text.codepoint = token.codepoint;
+			prim[n].u.text.font = token.font;
+			prim[n].u.text.size = ctx.fs->size;
+			prim[n].u.text.color = ctx.color;
+		}
+		++n;
 	}
 	if (ctx.x > ctx.line_width)
 		ctx.line_width = ctx.x;
@@ -864,7 +955,8 @@ ltext_(lua_State *L, struct styles *s, int gen_layout, int external) {
 				prim[i].pos.y += offy;
 			}
 		}
-		lua_pushexternalstring(L, buffer, n * sizeof(struct text_primitive), free_primitive, NULL);
+		lua_pushexternalstring(L, (char *)prim,
+			n * sizeof(struct text_primitive), free_primitive, NULL);
 		lua_pushinteger(L, height);
 		return 2;
 	} else {

--- a/test/text.lua
+++ b/test/text.lua
@@ -47,7 +47,8 @@ local fontid = font_init()
 local fontcobj = font.cobj()
 
 local callback = {}
-local WIDTH <const> = 200
+local WIDTH_MIN <const> = 120
+local WIDTH_MAX <const> = 300
 local HEIGHT <const> = 200
 local VIEWPORT_MIN <const> = 48
 local VIEWPORT_MAX <const> = HEIGHT
@@ -60,7 +61,9 @@ function callback.window_resize(w, h)
 	screen_h = h
 end
 
-local TEXT <const> = "[004000]Hello[n], 这个句子中有[s1]大字[n]，也有[s2]小字[n]。这句话会在文本区居中。"
+local TEXT <const> = [[[004000][w1]Hello[w][n], 这个句子中有[s1]大字[n]，也有[s2]小字[n]。这句话会在文本区居中
+ 这里追加一段 [w2]English[w] 和中文混排，[w3]no-break[w] [w4]words[w] 会随着宽度变化整体换行。
+ [w5]超长不可分割分组会在比整行更宽时退回逐字换行[w]。]]
 -- size 32; color 0; alignment center
 -- local block, layout = mattext.block(fontcobj, fontid, 32, 0, "CV")
 local function text_block()
@@ -73,10 +76,9 @@ local function text_block()
 end
 
 local block, layout = text_block()
--- Verify block closures keep the local styles object alive.
-collectgarbage "collect"
-local label = block(TEXT, WIDTH, HEIGHT)
-local label_layout = layout(TEXT, WIDTH, HEIGHT)
+local label = nil
+local label_layout = nil
+local label_width = 0
 
 local cursor_pos = 0
 local selection_anchor = nil
@@ -88,8 +90,24 @@ local function viewport_height(count)
 	return math.floor(VIEWPORT_MIN + (VIEWPORT_MAX - VIEWPORT_MIN) * t)
 end
 
-local function position()
-	local x = (screen_w - WIDTH) / 2
+local function viewport_width(count)
+	local t = (math.sin(count * 0.018 + 1.3) + 1) * 0.5
+	return math.floor(WIDTH_MIN + (WIDTH_MAX - WIDTH_MIN) * t)
+end
+
+local function update_label(width)
+	if width == label_width then
+		return
+	end
+	label_width = width
+	label = block(TEXT, width, HEIGHT)
+	label_layout = layout(TEXT, width, HEIGHT)
+end
+
+update_label(WIDTH_MAX)
+
+local function position(width)
+	local x = (screen_w - width) / 2
 	local y = (screen_h - HEIGHT) / 2
 	return x, y
 end
@@ -142,10 +160,12 @@ local function draw_selection(x, y)
 end
 
 function callback.frame(count)
-	local x, y = position()
 	local clip_h = viewport_height(count)
-	batch:add(matquad.quad(WIDTH, clip_h, 0x400000ff), x, y)
-	batch:add(matclip.rect(WIDTH + CLIP_BLEED * 2, clip_h), x - CLIP_BLEED, y)
+	local width = viewport_width(count)
+	update_label(width)
+	local x, y = position(width)
+	batch:add(matquad.quad(width, clip_h, 0x400000ff), x, y)
+	batch:add(matclip.rect(width + CLIP_BLEED * 2, clip_h), x - CLIP_BLEED, y)
 	draw_selection(x, y)
 	batch:add(label, x, y)
 	-- cursor
@@ -172,7 +192,7 @@ local mouse_x = 0
 local mouse_y = 0
 
 local function hit_text(x, y)
-	local ox, oy = position()
+	local ox, oy = position(label_width)
 	return label_layout:hit_test(x - ox, y - oy)
 end
 


### PR DESCRIPTION
加了个 [wN]/[w] 语法用于控制单词的 no-break 换行, 这样业务侧可以按需对不同语种进行换行控制

<img width="875" height="444" alt="image" src="https://github.com/user-attachments/assets/9e2f7464-7265-47cd-9dae-2f79ceced97d" />
